### PR TITLE
reduce numBuffers to 3

### DIFF
--- a/module-sles-sink.c
+++ b/module-sles-sink.c
@@ -212,7 +212,7 @@ static int pa_init_sles_player(struct userdata *s, SLint32 sl_rate)
 	
 	SLDataLocator_BufferQueue locator_bufferqueue;
 	locator_bufferqueue.locatorType = DATALOCATOR_BUFFERQUEUE;
-	locator_bufferqueue.numBuffers = 50;
+	locator_bufferqueue.numBuffers = 3;
 	
 	if (sl_rate < SL_SAMPLINGRATE_8 || sl_rate > SL_SAMPLINGRATE_192) {
 		pa_log("Incompatible sample rate");


### PR DESCRIPTION
From AudioTrack's warning we can see that numBuffers should be between the range of 1 to 8:

02-02 21:03:54.330 32531 32531 W AudioTrack: notificationFrames=-50 clamped to the range -1 to -8
02-02 21:03:54.335 32531 32531 D AudioTrack: Client defaulted notificationFrames to 192 for frameCount 1536

For now we set it to 3 base on the fact that (frameCount / notificationFrames) is around 3 when the rate used is non-optimal:

02-02 21:04:21.452 32577 32577 W AudioTrack: notificationFrames=-50 clamped to the range -1 to -8
02-02 21:04:21.460 32577 32577 W AudioTrack: AUDIO_OUTPUT_FLAG_FAST denied by client; transfer 1, track 44100 Hz, output 48000 Hz
02-02 21:04:21.463 32577 32577 D AudioTrack: Client defaulted notificationFrames to 590 for frameCount 1772

02-02 21:04:38.964 32620 32620 W AudioTrack: notificationFrames=-50 clamped to the range -1 to -8
02-02 21:04:38.974 32620 32620 W AudioTrack: AUDIO_OUTPUT_FLAG_FAST denied by client; transfer 1, track 96000 Hz, output 48000 Hz
02-02 21:04:38.975 32620 32620 D AudioTrack: Client defaulted notificationFrames to 1282 for frameCount 3848